### PR TITLE
add openvz support for new ctop version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,10 +38,10 @@ Features
 - optionally fold/unfold sub cgroup tree
 - optionally follow selected cgroup/container
 - optionnaly pause the refresh (typically, to select text)
-- detects Docker, LXC, unprivileged LXC and systemd based containers
-- supports advanced features for Docker and LXC based containers
+- detects Docker, LXC, unprivileged LXC, OpenVZ and systemd based containers
+- supports advanced features for Docker, LXC and OpenVZ based containers
 - open a shell/attach to supported container types for further diagnose
-- stop/kill supported container types
+- stop/kill/chekpointing supported container types
 - click to sort / reverse
 - click to select cgroup
 - no external dependencies beyond Python >= 2.6 or Python >= 3.0
@@ -113,12 +113,13 @@ Usage
 - click on title line to select sort column / reverse sort order.
 - click on any container line to select it.
 
-Additionally, for supported container types (Currently Docker and LXC):
+Additionally, for supported container types (Currently Docker, LXC and OpenVZ):
 
 - press ``a`` to attach to console output.
 - press ``e`` to open a shell in the container context. Aka 'enter' container.
 - press ``s`` to stop the container (SIGTERM).
 - press ``k`` to kill the container (SIGKILL).
+- press ``c`` to checkpointing the container(OpenVZ only now - run 'vzctl chkpnt CTID')
 
 Requirements
 ------------

--- a/cgroup_top.py
+++ b/cgroup_top.py
@@ -315,7 +315,8 @@ def get_user_beacounts():
        prefix = ['sudo']
 
     command = prefix + ['vzlist', '-o', 'ctid,privvmpages,privvmpages.l', '-H']
-    return os.popen(" ".join(command)).readlines()
+    output, err = subprocess.Popen(command, shell=False, stdout=subprocess.PIPE).communicate()
+    return output
 
 
 def collect(measures):
@@ -365,8 +366,9 @@ def collect(measures):
     #Collect memory statistics for openvz
     if HAS_OPENVZ:
         user_beancounters = get_user_beacounts()
-        for line in user_beancounters:
-            line = line.replace('\n','')
+        for line in user_beancounters.split('\n'):
+            if line == '':
+                continue
             undef, ctid, privvmpages, limit = re.split('\s+', line)
             ctid = '/' + ctid
             if 'tasks' not in cur[ctid]:


### PR DESCRIPTION
New request instead of https://github.com/yadutaf/ctop/pull/10 .

How I see I cannot work correct with **collect_ensure_common()** with openvz.
I move memory statistic to down and skip it on openvz, if if have not tasks.
In this version it work on node with https://github.com/yadutaf/ctop/issues/9, how I see.

Added key 'c' like checkpoint(it same that suspend in openvz, but not see like "stop") for openvz containers.

Other minor fixes for previos ugly moments like get_user_beacounts('root').
