### PR TITLE
fix for openvz get memory, additional check

### DIFF
--- a/cgroup_top.py
+++ b/cgroup_top.py
@@ -366,6 +366,12 @@ def collect(measures):
     #Collect memory statistics for openvz
     if HAS_OPENVZ:
         user_beancounters = get_user_beacounts()
+        # We have lines like - 
+        #      1202     202419    2457600
+        #      1203     299835    2457600
+        #      1207      54684    2457600
+        #      1210     304939    2457600
+        #1000001212      13493    2457600
         for line in user_beancounters.split('\n'):
             if line == '':
                 continue

--- a/cgroup_top.py
+++ b/cgroup_top.py
@@ -369,7 +369,11 @@ def collect(measures):
         for line in user_beancounters.split('\n'):
             if line == '':
                 continue
-            undef, ctid, privvmpages, limit = re.split('\s+', line)
+            line = re.sub(r'^\s+', '', line)
+            splited_line = re.split('\s+', line)
+            if len(splited_line) != 3:
+                continue
+            ctid, privvmpages, limit = splited_line
             ctid = '/' + ctid
             if 'tasks' not in cur[ctid]:
                 continue


### PR DESCRIPTION
Vzlist output line parsed more correctly now.
It crashed if output have very big CTID numbers in old variant.
