### PR TITLE
Improves and optimizes the size of the resulting Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
-FROM python:3
+FROM python:2-alpine
 MAINTAINER Jean-Tiare Le Bigot <jt@yadutaf.fr>
 
-WORKDIR /src
-ADD . /src
-RUN python ./setup.py install
+ENTRYPOINT ["ctop"]
+CMD []
 
-CMD ["ctop"]
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install -r /tmp/requirements.txt && rm /tmp/requirements.txt
 
+WORKDIR /app
+COPY . /app/
+RUN pip install .


### PR DESCRIPTION
``` #!bsh
$ docker images prologic/ctop
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
prologic/ctop       latest              3a6cdf7c6d24        19 minutes ago      25.86 MB
```

This allows one to use and downloads ctop much faster :)
