### PR TITLE
Add qemu type

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,8 @@ Features
 - optionnaly pause the refresh (typically, to select text)
 - detects Docker, LXC, unprivileged LXC, OpenVZ and systemd based containers
 - supports advanced features for Docker, LXC and OpenVZ based containers
+- detects qemu-kvm virtual machines (with libvirt only)
+- supports advanced features for qemu-kvm VMs (via virsh)
 - open a shell/attach to supported container types for further diagnose
 - stop/kill/chekpointing supported container types
 - click to sort / reverse


### PR DESCRIPTION
Add support qemu-kvm VMs with libvrit.
Befor  - 
![ctop_befor](https://user-images.githubusercontent.com/7100008/30390035-789e787c-98bd-11e7-8d13-e4b68230fd02.png)
After - 
![ctop_after](https://user-images.githubusercontent.com/7100008/30390052-81452b60-98bd-11e7-9b83-898543067012.png)

Add actions
 - attach via `virsh console domain`
 - stop via `virsh shutdown domain`
 - kill via `virsh destroy domain`

Successful tested on Centos 7.